### PR TITLE
Fix#20

### DIFF
--- a/util.ps1
+++ b/util.ps1
@@ -549,6 +549,8 @@ function Read-Config {
             throw "An error occured loading config from $configfile.  $_"
         }
     }
+    write-progress -Activity "Loading from Config $($inobj._configdate) in file $configfile" -Completed
+    
 }
 
 function New-ConnectionProfile {


### PR DESCRIPTION
- Add -completed to read-config if configfile doesnt exist.

Signed-off-by: Nick Bradford <nbradford@vmware.com>