### PR TITLE
Fix a bug where L2 Bridging causes test to fail

### DIFF
--- a/HealthCheck/testNSXDlrHostRoutingTable.Tests.ps1
+++ b/HealthCheck/testNSXDlrHostRoutingTable.Tests.ps1
@@ -238,7 +238,7 @@ else{
 
     } while(($choice -lt 1) -or ($choice -gt $dlrs.Count))
     $dlrname = $dlrs[$choice-1].name
-    $tzID = $dlrs[$choice-1].edgeSummary.logicalRouterScopes.logicalRouterScope.id
+    $tzID = ($dlrs[$choice-1].edgeSummary.logicalRouterScopes.logicalRouterScope | ?{$_.Type -eq "TransportZone"}).id
 }
 
 # get clusters in the same transport zone where DLR resides

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MIT
 NSX Power Operations is a platform that provides NSX users a way to document their VMware NSX for vSphere environment in Microsoft Excel and Visio files that are easily consumable and referable. The documentation not only captures the Desired State (configuration) but also the Realized State (for example: routing & forwarding tables) across the distributed environment. The platform also embeds rich health check tools.
 
 ### Releases & Major Branches
-Current version: 2.0
+Current version: 2.1.1 (Feb 28, 2018)
 
 ### Documentation
 


### PR DESCRIPTION
Enabled L2 Bridging breaks the script initial logic of identifiying
the DLR's transport zone. The logic has been updated to avoid this
issue.

Signed-off-by: Askar Kopbayev <akopbayev@icloud.com>

Resolves: #80