### PR TITLE
Replicator Service Check

### DIFF
--- a/HealthCheck/testNSXManager.Tests.ps1
+++ b/HealthCheck/testNSXManager.Tests.ps1
@@ -70,10 +70,11 @@ Describe "NSX Manager" {
     }
     Write-Verbose "Enabled: $(($ComponentSummary | ? { $_.name -match 'RabbitMQ'}).enabled), Running $(($ComponentSummary | ? { $_.name -match 'RabbitMQ'}).status)"
 
+    if ((get-nsxmanagerrole).role -eq "Primary") {
     it "has the NSX Replicator Service in a running state" {
         ($ComponentSummary | ? { $_.name -match 'NSX Replicator'}).status | should match RUNNING
-    }
+        }
     Write-Verbose "Enabled: $(($ComponentSummary | ? { $_.name -match 'NSX Replicator'}).enabled), Running $(($ComponentSummary | ? { $_.name -match 'NSX Replicator'}).status)"
-
+    }
 }
 

--- a/HealthCheck/testNSXManager.Tests.ps1
+++ b/HealthCheck/testNSXManager.Tests.ps1
@@ -70,11 +70,15 @@ Describe "NSX Manager" {
     }
     Write-Verbose "Enabled: $(($ComponentSummary | ? { $_.name -match 'RabbitMQ'}).enabled), Running $(($ComponentSummary | ? { $_.name -match 'RabbitMQ'}).status)"
 
-    if ((get-nsxmanagerrole).role -eq "Primary") {
+    if((get-nsxmanagerrole).role -eq "Primary") {
     it "has the NSX Replicator Service in a running state" {
         ($ComponentSummary | ? { $_.name -match 'NSX Replicator'}).status | should match RUNNING
         }
     Write-Verbose "Enabled: $(($ComponentSummary | ? { $_.name -match 'NSX Replicator'}).enabled), Running $(($ComponentSummary | ? { $_.name -match 'NSX Replicator'}).status)"
+    } else {
+    it "has the NSX Replicator Service in a stopped state" {
+            ($ComponentSummary | ? { 
+                $_.name -match 'NSX Replicator'}).status | should match STOPPED
+        }
     }
 }
-


### PR DESCRIPTION
testNSXManager.Tests.ps1 script now checks the role of NSX manager and runs the replicator service check only the NSX manager's role is Primary. This check will be skipped for any other role.