### PR TITLE
Add menu option to set connection profile

### DIFF
--- a/nsx-PowerOps.ps1
+++ b/nsx-PowerOps.ps1
@@ -1531,7 +1531,8 @@ __/\\\\\\\\\\\__________________________________________________________________
         $Footer = { 
 @"
 Default Connection Profile: $($Config.DefaultProfile)
-Connected : $($DefaultNsxConnection -and $DefaultNsxConnection.ViConnection.IsConnected)
+Current Connection Profile: $(if(!$DefaultNSXConnection){"N/A"} else {foreach($key in $config.profiles.GetEnumerator() | ?{$_.value.NSXServer -eq $DefaultNSXConnection.Server}){$key.name}})
+Connected: $($DefaultNsxConnection -and $DefaultNsxConnection.ViConnection.IsConnected)
 Output Directory: $DocumentLocation
 "@
         }
@@ -1681,7 +1682,7 @@ Output Directory: $DocumentLocation
         # Authentication profile menu definition.
         $AuthConfigMenu = @{
             
-            "Name" = "Configure Connection Profiles"
+            "Name" = "Connection Profiles"
             "Status" = { 
                 if ( -not (checkDependancies -ListAvailable $true) ) {
                     "Disabled"
@@ -1733,6 +1734,36 @@ Output Directory: $DocumentLocation
                     "HelpText" = "Deletes an existing connection profile."
                     "Script" = { Remove-ConnectionProfile; if ((-not ($Config.DefaultProfile)) -and ($DefaultNSXConnection)) { disconnectDefaultNsxConnection } }
                 },
+                @{
+                    "Name" = "Set Current Connection Profile"
+                    "Status" = { 
+                        If ($DefaultNsxConnection -and $DefaultNsxConnection.ViConnection.IsConnected) {
+                            "SelectedValid" 
+                        } 
+                        elseif ( $Config.Profiles -and ($Config.Profiles.Count -gt 0) ) {
+                            "MenuValid"
+                        }
+                        else {
+                            "Disabled" 
+                        }
+                    }
+                    "StatusText" = {
+                        If ( $DefaultNsxConnection -and $DefaultNsxConnection.ViConnection.IsConnected ) {
+                            foreach($key in $config.profiles.GetEnumerator() | ?{$_.value.NSXServer -eq $DefaultNSXConnection.Server}){
+                                $key.name
+                            }
+                        } 
+                        elseif ( $Config.Profiles -and ($Config.Profiles.Count -gt 0) ) {
+                            "SELECT"
+                        }
+                        else {
+                            "No Connection Profiles Defined" 
+                        }
+                    }
+                    "HelpText" = "Selects the connection profile used for interactive operations that require access to NSX/VC."
+                    "Script" = { Set-ConnectionProfile }
+                },
+
                 @{
                     "Name" = "Select Default Connection Profile"
                     "Status" = { 

--- a/util.ps1
+++ b/util.ps1
@@ -428,6 +428,49 @@ function Set-DefaultConnectionProfile {
     show-menuv2 -menu $ConnectionProfileMenu | out-null
 }
 
+function Set-ConnectionProfile {
+    
+    $ConnectionProfileMenu = @{ 
+        "Script" = {}
+        "Status" = { "MenuEnabled" }
+        "Name" = "Set Current Connection Profile"
+        "HelpText" = "Connects existing connection profile"
+        "MainHeader" = $MainHeader
+        "Subheader" = $Subheader
+        "Footer" = $footer
+        "Items" = New-Object System.Collections.Arraylist
+    }
+    foreach ( $profilename in $Config.Profiles.Keys ) {
+        $ConnectionProfileMenu.Items.Add(
+            @{ 
+                "Name" = $profileName
+                "Status" = {
+                    if ($profileName -eq $config.DefaultProfile) {
+                        "SelectedValid"
+                    } 
+                    else { 
+                        "UnselectedValid"
+                    }
+                }
+                "StatusText" = {
+                    if ($profileName -eq $config.DefaultProfile) { 
+                        "Default" 
+                    }
+                    else {
+                        "Select"
+                    }
+                }
+                "Script" = { 
+                    connectProfile $($ConnectionProfileMenu.Items[$SelectedItemNumber].name)
+                    set-variable -scope 1 -name menuexit -value $true
+                    "Set Connection Profile $ProfileName"
+                }
+            } 
+        ) | out-null
+    }
+    show-menuv2 -menu $ConnectionProfileMenu | out-null
+}
+
 function Get-ProfileConnection {
 
     param ( 


### PR DESCRIPTION
Added another option under connection profiles menu. The new option
allows to re-connect to another connection profile without restarting the
NSX-PowerOPs

The menu footer was updated to reflect the Current Connection Profile

Signed-ff-by: Askar Kopbayev <akopbayev@icloud.com>

Resolves: #64